### PR TITLE
Update serviceInstance.py for ga compatibility

### DIFF
--- a/scripts/serviceInstance.py
+++ b/scripts/serviceInstance.py
@@ -33,6 +33,8 @@ class ServiceInstanceCmd(object):
             self._left_vn_fq_name = [self._args.domain_name, self._args.proj_name, self._args.left_vn]
         if self._args.right_vn:
             self._right_vn_fq_name = [self._args.domain_name, self._args.proj_name, self._args.right_vn]
+        if self._args.mgmt_vn:
+            self._mgmt_vn_fq_name = [self._args.domain_name, self._args.proj_name, self._args.mgmt_vn]
 
         self._vnc_lib = VncApi('u', 'p', 
                          api_server_host = self._args.api_server_ip, 
@@ -138,9 +140,9 @@ class ServiceInstanceCmd(object):
             si_obj = ServiceInstance(self._args.instance_name, parent_obj = project)
             si_uuid = self._vnc_lib.service_instance_create(si_obj)
 
-        si_prop = ServiceInstanceType(left_virtual_network = self._args.left_vn, 
-                                      management_virtual_network = self._args.mgmt_vn,
-                                      right_virtual_network = self._args.right_vn)
+        si_prop = ServiceInstanceType(left_virtual_network = ":".join(self._args.left_vn), 
+                                      management_virtual_network = ":".join(self._args.mgmt_vn),
+                                      right_virtual_network = ":".join(self._args.right_vn))
 
         #set scale out
         scale_out = ServiceScaleOutType(max_instances = self._args.max_instances, 


### PR DESCRIPTION
Oops - hold on, this might not be right. It's plausible it's only the left network that needs fq: the others don't seem to be giving an IP out...investigating... skip this.

```
Build 165 seems to want a fully qualified argument for the *_virtual_networks..
Previously, it was undecorated.
```
